### PR TITLE
Handle fetch errors for Supabase requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,6 +47,15 @@ app.post('/tools/supabase_select', async (req, res) => {
       url += `&order=${encodeURIComponent(order.column)}.${order.ascending ? 'asc' : 'desc'}`;
     }
     const response = await fetch(url, { headers: supabaseHeaders });
+    if (!response.ok) {
+      let errorBody;
+      try {
+        errorBody = await response.json();
+      } catch (e) {
+        errorBody = await response.text();
+      }
+      return res.status(response.status).json({ error: errorBody });
+    }
     const data = await response.json();
     res.json(data);
   } catch (err) {
@@ -73,6 +82,15 @@ app.post('/tools/supabase_insert', async (req, res) => {
       },
       body: JSON.stringify(rows)
     });
+    if (!response.ok) {
+      let errorBody;
+      try {
+        errorBody = await response.json();
+      } catch (e) {
+        errorBody = await response.text();
+      }
+      return res.status(response.status).json({ error: errorBody });
+    }
     const data = await response.json();
     res.json(data);
   } catch (err) {


### PR DESCRIPTION
## Summary
- Validate Supabase fetch responses for `supabase_select`
- Validate Supabase fetch responses for `supabase_insert`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3eb8f006c832680123669cd4748d9