### PR TITLE
Restrict CORS origins via env variable

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,10 @@
+# Deployment Notes
+
+Set the following environment variables before running the server:
+
+- `SUPABASE_URL` – Base URL of your Supabase project.
+- `SUPABASE_ANON_KEY` – Anon key for your Supabase project.
+- `ALLOWED_TABLES` – Comma-separated list of tables the server can access.
+- `ALLOW_WRITES` – Set to `true` to enable insert operations.
+- `ALLOWED_ORIGINS` – Comma-separated list of allowed origins for CORS.
+

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const path = require('path');
 const app = express();
 const port = process.env.PORT || 3000;
 
-app.use(cors());
+app.use(cors({ origin: process.env.ALLOWED_ORIGINS?.split(',') || [] }));
 app.use(express.json());
 
 // Health check


### PR DESCRIPTION
## Summary
- limit CORS to origins listed in `ALLOWED_ORIGINS`
- document deployment environment variables

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3eb9288888326b9133891bf71e4de