### PR TITLE
chore: parameterize API host

### DIFF
--- a/ai-plugin.json
+++ b/ai-plugin.json
@@ -5,7 +5,11 @@
   "description_for_human": "A connector for Supabase using MCP. Supports reading and writing tables.",
   "description_for_model": "Use this connector to run supabase_select and supabase_insert on your Supabase database.",
   "auth": { "type": "none" },
-  "api": { "type": "openapi", "url": "https://mcp-supabase-render.onrender.com/openapi.json" },
+  "api": {
+    "type": "openapi",
+    "url": "{{HOST}}/openapi.json",
+    "_comment": "Deployment scripts must inject the actual host."
+  },
   "logo_url": "",
   "contact_email": "",
   "legal_info_url": ""


### PR DESCRIPTION
## Summary
- parameterize api URL with {{HOST}} placeholder
- note that deployment scripts should inject actual host

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3eb8f4da4832693e55392918c262d