### PR TITLE
Handle default CORS behavior when ALLOWED_ORIGINS unset

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,18 @@ const path = require('path');
 
 const app = express();
 const port = process.env.PORT || 3000;
+const rawOrigins = process.env.ALLOWED_ORIGINS || '';
+const ALLOWED_ORIGINS = rawOrigins
+  .split(',')
+  .map(o => o.trim())
+  .filter(Boolean);
 
-app.use(cors({ origin: process.env.ALLOWED_ORIGINS?.split(',') || [] }));
+if (ALLOWED_ORIGINS.length === 0) {
+  // Allow all origins if ALLOWED_ORIGINS is not specified
+  app.use(cors());
+} else {
+  app.use(cors({ origin: ALLOWED_ORIGINS }));
+}
 app.use(express.json());
 
 // Health check


### PR DESCRIPTION
## Summary
- Configure CORS to allow all origins when `ALLOWED_ORIGINS` is not set
- Pass explicit origin list when provided

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3ed5feeb48326a711e1e45bf3852d