### PR TITLE
Handle empty body in supabase_insert

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,39 @@
+# Testing Instructions
+
+This project does not include automated tests. To manually verify the `/tools/supabase_insert` endpoint behaves correctly for both response representations:
+
+1. **Start the server** with environment variables:
+   - `SUPABASE_URL`
+   - `SUPABASE_ANON_KEY`
+   - `ALLOWED_TABLES` (comma separated list containing the target table)
+   - `ALLOW_WRITES=true`
+
+   ```bash
+   SUPABASE_URL=... SUPABASE_ANON_KEY=... ALLOWED_TABLES=my_table ALLOW_WRITES=true node index.js
+   ```
+
+2. **Insert with representation** (`returnRepresentation: true`).
+
+   ```bash
+   curl -X POST http://localhost:3000/tools/supabase_insert \
+     -H 'Content-Type: application/json' \
+     -d '{"table":"my_table","rows":[{"col":"value"}],"returnRepresentation":true}'
+   ```
+
+   Expect a JSON response containing the inserted row.
+
+3. **Insert without representation** (`returnRepresentation: false`).
+
+   ```bash
+   curl -X POST http://localhost:3000/tools/supabase_insert \
+     -H 'Content-Type: application/json' \
+     -d '{"table":"my_table","rows":[{"col":"value"}],"returnRepresentation":false}'
+   ```
+
+   Expect a response of:
+
+   ```json
+   {"success": true}
+   ```
+
+These steps confirm that the handler returns the inserted rows when requested and a simple success status when no representation is needed.

--- a/index.js
+++ b/index.js
@@ -95,7 +95,13 @@ app.post('/tools/supabase_insert', async (req, res) => {
       }
       return res.status(response.status).json({ error: errorBody });
     }
-    const data = await response.json();
+    const contentLength = response.headers.get('content-length');
+    let data;
+    if (returnRepresentation || (contentLength && contentLength !== '0')) {
+      data = await response.json();
+    } else {
+      data = { success: true };
+    }
     res.json(data);
   } catch (err) {
     res.status(500).json({ error: err.message });


### PR DESCRIPTION
## Summary
- Safely handle Supabase insert responses without bodies by returning `{ success: true }`
- Add manual testing instructions for verifying both response representations

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a3ed617e248326a20d9d8490b84bba